### PR TITLE
Update support for TeamCity 2019.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Posts Build Status to [MsTeams](http://teams.microsoft.com).  This plugin is bas
 ![Sample Notification](https://raw.github.com/spyder007/teamcity-msteams-notifier/master/docs/build-status_pass.png)
 ![Sample Notification](https://raw.github.com/spyder007/teamcity-msteams-notifier/master/docs/build-status_fail.png)
 
-_Tested on TeamCity 2017.2 (build 50574)_
+_Tested on TeamCity 2019.1 (build 65998)_
 
 ## Installation
 Head over to the [releases](https://github.com/spyder007/teamcity-msteams-notifier/releases) section and get the zip labelled `tcMsTeamsNotifierPlugin.zip` from there (do not download the one on this page). Copy the zip file into your [TeamCity plugins directory](https://confluence.jetbrains.com/display/TCD9/Installing+Additional+Plugins).

--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
     <groupId>spyder007.teamcity.plugins.tcmsteamsnotifications</groupId>
     <artifactId>tcmsteamsbuildnotifier</artifactId>
     <properties>
-        <teamcity-version>10.0.5</teamcity-version>
-        <majorVersion>1</majorVersion>
+        <teamcity-version>2019.1</teamcity-version>
+        <majorVersion>2</majorVersion>
         <minorVersion>0</minorVersion>
-        <patchVersion>7</patchVersion>
+        <patchVersion>0</patchVersion>
         <currentVersion>${majorVersion}.${minorVersion}.${patchVersion}</currentVersion>
     </properties>
     <version>${currentVersion}</version>
@@ -118,6 +118,10 @@
         <repository>
             <id>tcmsteamsnotifications.sourceforge</id>
             <url>http://svn.code.sf.net/p/tcplugins/code/maven2-repo</url>
+        </repository>
+        <repository>
+            <id>jetbrains-all</id>
+            <url>https://download.jetbrains.com/teamcity-repository</url>
         </repository>
     </repositories>
 

--- a/tcmsteamsbuildnotifier-core/pom.xml
+++ b/tcmsteamsbuildnotifier-core/pom.xml
@@ -143,18 +143,6 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<!-- TeamCity/webapps/WEB-INF/lib/runtime-util.jar -->
-		<!--<dependency>
-			<groupId>com.jetbrains.teamcity</groupId>
-			<artifactId>runtime-util</artifactId>
-			<version>7.1.0</version>
-			<scope>provided</scope>
-		</dependency>-->
-
-		<!-- TeamCity/webapps/WEB-INF/lib/server-model.jar -->
-		<!-- <dependency> <groupId>com.jetbrains.teamcity</groupId> <artifactId>model</artifactId> 
-			<version>4.0.2</version> <scope>provided</scope> </dependency> -->
-
 		<!-- TeamCity/webapps/WEB-INF/lib/common-api.jar -->
 		<dependency>
 			<groupId>org.jetbrains.teamcity</groupId>
@@ -163,22 +151,12 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<!-- <dependency> <groupId>com.jetbrains.teamcity</groupId> <artifactId>openapi</artifactId> 
-			<version>7.1.0</version> <scope>provided</scope> </dependency> -->
-
 		<dependency>
 			<groupId>com.intellij</groupId>
 			<artifactId>openapi</artifactId>
 			<version>7.0.3</version>
 			<scope>provided</scope>
 		</dependency>
-
-		<!--<dependency>
-			<groupId>com.jetbrains.teamcity</groupId>
-			<artifactId>annotations</artifactId>
-			<version>7.1.0</version>
-			<scope>provided</scope>
-		</dependency>-->
 
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/tcmsteamsbuildnotifier-core/pom.xml
+++ b/tcmsteamsbuildnotifier-core/pom.xml
@@ -137,19 +137,19 @@
 
 		<!-- TeamCity/webapps/WEB-INF/lib/server-api.jar -->
 		<dependency>
-			<groupId>com.jetbrains.teamcity</groupId>
+			<groupId>org.jetbrains.teamcity</groupId>
 			<artifactId>server-api</artifactId>
-			<version>8.0.0</version>
+			<version>2019.1</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<!-- TeamCity/webapps/WEB-INF/lib/runtime-util.jar -->
-		<dependency>
+		<!--<dependency>
 			<groupId>com.jetbrains.teamcity</groupId>
 			<artifactId>runtime-util</artifactId>
 			<version>7.1.0</version>
 			<scope>provided</scope>
-		</dependency>
+		</dependency>-->
 
 		<!-- TeamCity/webapps/WEB-INF/lib/server-model.jar -->
 		<!-- <dependency> <groupId>com.jetbrains.teamcity</groupId> <artifactId>model</artifactId> 
@@ -157,9 +157,9 @@
 
 		<!-- TeamCity/webapps/WEB-INF/lib/common-api.jar -->
 		<dependency>
-			<groupId>com.jetbrains.teamcity</groupId>
+			<groupId>org.jetbrains.teamcity</groupId>
 			<artifactId>common-api</artifactId>
-			<version>8.0.0</version>
+			<version>2019.1</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -173,12 +173,12 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<dependency>
+		<!--<dependency>
 			<groupId>com.jetbrains.teamcity</groupId>
 			<artifactId>annotations</artifactId>
 			<version>7.1.0</version>
 			<scope>provided</scope>
-		</dependency>
+		</dependency>-->
 
 		<dependency>
 			<groupId>javax.servlet</groupId>
@@ -206,7 +206,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.4</version>
+            <version>2.8.5</version>
             <scope>compile</scope>
         </dependency>
 

--- a/tcmsteamsbuildnotifier-core/src/test/java/msteamsnotifications/teamcity/MockSBuildAgent.java
+++ b/tcmsteamsbuildnotifier-core/src/test/java/msteamsnotifications/teamcity/MockSBuildAgent.java
@@ -3,6 +3,7 @@ package msteamsnotifications.teamcity;
 import jetbrains.buildServer.BuildAgent;
 import jetbrains.buildServer.LicenseNotGrantedException;
 import jetbrains.buildServer.serverSide.*;
+import jetbrains.buildServer.serverSide.agentPools.AgentPool;
 import jetbrains.buildServer.serverSide.comments.Comment;
 import jetbrains.buildServer.users.SUser;
 import jetbrains.buildServer.users.User;
@@ -10,6 +11,7 @@ import jetbrains.buildServer.users.User;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class MockSBuildAgent implements SBuildAgent, BuildAgent {
 
@@ -20,8 +22,7 @@ public class MockSBuildAgent implements SBuildAgent, BuildAgent {
 	private String osVersion;
 	private SRunningBuild sRunningBuild;
 
-	public MockSBuildAgent(String agentName, String hostname, String ipAddress,
-			int agentId, String osVersion) {
+	public MockSBuildAgent(String agentName, String hostname, String ipAddress, int agentId, String osVersion) {
 		this.name = agentName;
 		this.hostame = hostname;
 		this.ipAddress = ipAddress;
@@ -91,10 +92,10 @@ public class MockSBuildAgent implements SBuildAgent, BuildAgent {
 		return null;
 	}
 
-	public void setRunningBuild(SRunningBuild sRunningBuild){
+	public void setRunningBuild(SRunningBuild sRunningBuild) {
 		this.sRunningBuild = sRunningBuild;
 	}
-	
+
 	public SRunningBuild getRunningBuild() {
 		return this.sRunningBuild;
 	}
@@ -152,8 +153,7 @@ public class MockSBuildAgent implements SBuildAgent, BuildAgent {
 
 	}
 
-	public void setAuthorized(boolean arg0, SUser arg1, String arg2)
-			throws LicenseNotGrantedException {
+	public void setAuthorized(boolean arg0, SUser arg1, String arg2) throws LicenseNotGrantedException {
 		// TODO Auto-generated method stub
 
 	}
@@ -233,15 +233,50 @@ public class MockSBuildAgent implements SBuildAgent, BuildAgent {
 
 	public void setEnabled(boolean arg0, SUser arg1, String arg2, long arg3) {
 		// TODO Auto-generated method stub
-		
+
 	}
-	
+
 	// From tc 7.1
 
 	@Override
 	public int getAgentTypeId() {
 		// TODO Auto-generated method stub
 		return 0;
+	}
+
+	@Override
+	public Set<String> getAvailableRunTypeIds() {
+		return null;
+	}
+
+	@Override
+	public int getAgentPoolId() {
+		return 0;
+	}
+
+	@Override
+	public String describe(boolean arg0) {
+		return null;
+	}
+
+	@Override
+	public AgentPool getAgentPool() {
+		return null;
+	}
+
+	@Override
+	public String getCommunicationProtocolDescription() {
+		return null;
+	}
+
+	@Override
+	public String getCommunicationProtocolType() {
+		return null;
+	}
+
+	@Override
+	public boolean isCloudAgent() {
+		return false;
 	}
 	
 

--- a/tcmsteamsbuildnotifier-core/src/test/java/msteamsnotifications/teamcity/MockSBuildType.java
+++ b/tcmsteamsbuildnotifier-core/src/test/java/msteamsnotifications/teamcity/MockSBuildType.java
@@ -16,6 +16,7 @@ import jetbrains.buildServer.serverSide.dependency.CyclicDependencyFoundExceptio
 import jetbrains.buildServer.serverSide.dependency.Dependency;
 import jetbrains.buildServer.serverSide.dependency.Dependent;
 import jetbrains.buildServer.serverSide.identifiers.DuplicateExternalIdException;
+import jetbrains.buildServer.serverSide.parameters.types.TypedValue;
 import jetbrains.buildServer.users.SUser;
 import jetbrains.buildServer.users.User;
 import jetbrains.buildServer.util.Option;
@@ -26,10 +27,11 @@ import java.io.File;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 public class MockSBuildType implements SBuildType {
-	
+
 	private SProject project;
 	private String name;
 	private ResponsibilityInfo responsibiltyInfo;
@@ -38,7 +40,7 @@ public class MockSBuildType implements SBuildType {
 	private RunType runType = new MockRunType();
 	private String description;
 	private String buildTypeId;
-	
+
 	public MockSBuildType(String name, String description, String buildTypeId) {
 		this.name = name;
 		this.description = description;
@@ -70,7 +72,6 @@ public class MockSBuildType implements SBuildType {
 		return null;
 	}
 
-
 	public void clearRunParameters() {
 		// TODO Auto-generated method stub
 
@@ -91,8 +92,7 @@ public class MockSBuildType implements SBuildType {
 		return null;
 	}
 
-	public <T extends SBuildAgent> AgentCompatibility getAgentCompatibility(
-			T arg0) {
+	public <T extends SBuildAgent> AgentCompatibility getAgentCompatibility(T arg0) {
 		// TODO Auto-generated method stub
 		return null;
 	}
@@ -136,7 +136,7 @@ public class MockSBuildType implements SBuildType {
 	}
 
 	public RunType getBuildRunner() {
-		return this.runType ;
+		return this.runType;
 	}
 
 	public <T extends BuildAgent> List<T> getCanRunAgents() {
@@ -144,8 +144,7 @@ public class MockSBuildType implements SBuildType {
 		return null;
 	}
 
-	public <T extends BuildAgent> List<T> getCanRunAndCompatibleAgents(
-			boolean arg0) {
+	public <T extends BuildAgent> List<T> getCanRunAndCompatibleAgents(boolean arg0) {
 		// TODO Auto-generated method stub
 		return null;
 	}
@@ -165,8 +164,7 @@ public class MockSBuildType implements SBuildType {
 		return 0;
 	}
 
-	public List<FilteredVcsChange> getFilteredChanges(SVcsModification arg0,
-			SBuild arg1) {
+	public List<FilteredVcsChange> getFilteredChanges(SVcsModification arg0, SBuild arg1) {
 		// TODO Auto-generated method stub
 		return null;
 	}
@@ -407,8 +405,7 @@ public class MockSBuildType implements SBuildType {
 
 	}
 
-	public void setName(String arg0) throws DuplicateBuildTypeNameException,
-			BuildTypeRenamingFailedException {
+	public void setName(String arg0) throws DuplicateBuildTypeNameException, BuildTypeRenamingFailedException {
 		this.name = arg0;
 	}
 
@@ -537,8 +534,7 @@ public class MockSBuildType implements SBuildType {
 
 	}
 
-	public void addDependency(Dependency arg0)
-			throws CyclicDependencyFoundException {
+	public void addDependency(Dependency arg0) throws CyclicDependencyFoundException {
 		// TODO Auto-generated method stub
 
 	}
@@ -582,15 +578,14 @@ public class MockSBuildType implements SBuildType {
 		return null;
 	}
 
-	public void removeResponsible(boolean arg0, User arg1, String arg2,
-			User arg3) {
+	public void removeResponsible(boolean arg0, User arg1, String arg2, User arg3) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	public void setResponsible(User arg0, String arg1, User arg2) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	public Collection<String> getRunnerTypes() {
@@ -600,22 +595,20 @@ public class MockSBuildType implements SBuildType {
 
 	public void addBuildFeature(SBuildFeatureDescriptor arg0) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
-	public SBuildFeatureDescriptor addBuildFeature(String arg0,
-			Map<String, String> arg1) {
+	public SBuildFeatureDescriptor addBuildFeature(String arg0, Map<String, String> arg1) {
 		// TODO Auto-generated method stub
 		return null;
 	}
 
 	public void addBuildRunner(SBuildRunnerDescriptor arg0) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
-	public SBuildRunnerDescriptor addBuildRunner(String arg0, String arg1,
-			Map<String, String> arg2) {
+	public SBuildRunnerDescriptor addBuildRunner(String arg0, String arg1, Map<String, String> arg2) {
 		// TODO Auto-generated method stub
 		return null;
 	}
@@ -627,12 +620,12 @@ public class MockSBuildType implements SBuildType {
 
 	public void addConfigParameter(Parameter arg0) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	public void applyRunnersOrder(String[] arg0) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	public SBuildRunnerDescriptor findBuildRunnerById(String arg0) {
@@ -702,7 +695,7 @@ public class MockSBuildType implements SBuildType {
 
 	public void removeAllBuildRunners() {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	public SBuildFeatureDescriptor removeBuildFeature(String arg0) {
@@ -722,35 +715,32 @@ public class MockSBuildType implements SBuildType {
 
 	public void removeConfigParameter(String arg0) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
-	public boolean replaceInValues(String arg0, String arg1)
-			throws PatternSyntaxException {
+	public boolean replaceInValues(String arg0, String arg1) throws PatternSyntaxException {
 		// TODO Auto-generated method stub
 		return false;
 	}
 
 	public void setBuildNumberPattern(String arg0) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
-	public boolean updateBuildFeature(String arg0, String arg1,
-			Map<String, String> arg2) {
+	public boolean updateBuildFeature(String arg0, String arg1, Map<String, String> arg2) {
 		// TODO Auto-generated method stub
 		return false;
 	}
 
-	public boolean updateBuildRunner(String arg0, String arg1, String arg2,
-			Map<String, String> arg3) {
+	public boolean updateBuildRunner(String arg0, String arg1, String arg2, Map<String, String> arg3) {
 		// TODO Auto-generated method stub
 		return false;
 	}
 
 	public void addParameter(Parameter arg0) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	public Collection<Parameter> getParametersCollection() {
@@ -760,7 +750,7 @@ public class MockSBuildType implements SBuildType {
 
 	public void removeParameter(String arg0) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	public CompatibilityResult getAgentCompatibility(AgentDescription arg0) {
@@ -783,15 +773,14 @@ public class MockSBuildType implements SBuildType {
 		return null;
 	}
 
-	public void attachToTemplate(BuildTypeTemplate arg0, boolean arg1)
-			throws InvalidVcsRootScopeException {
+	public void attachToTemplate(BuildTypeTemplate arg0, boolean arg1) throws InvalidVcsRootScopeException {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	public void detachFromTemplate() {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	public SBuildRunnerDescriptor findBuildRunnerByType(String arg0) {
@@ -866,21 +855,20 @@ public class MockSBuildType implements SBuildType {
 
 	public void moveToProject(SProject arg0, boolean arg1) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	public void persist() throws PersistFailedException {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	public void setPaused(boolean arg0, User arg1, String arg2) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
-	public boolean addVcsRoot(SVcsRoot arg0)
-			throws InvalidVcsRootScopeException, VcsRootNotFoundException {
+	public boolean addVcsRoot(SVcsRoot arg0) throws InvalidVcsRootScopeException, VcsRootNotFoundException {
 		// TODO Auto-generated method stub
 		return false;
 	}
@@ -893,13 +881,12 @@ public class MockSBuildType implements SBuildType {
 	public Collection<SBuildAgent> getCompatibleAgents() {
 		// TODO Auto-generated method stub
 		return null;
-	} 
-	
+	}
+
 	// From 7.1
 
 	@Override
-	public BuildTriggerDescriptor addBuildTrigger(String arg0,
-			Map<String, String> arg1) {
+	public BuildTriggerDescriptor addBuildTrigger(String arg0, Map<String, String> arg1) {
 		// TODO Auto-generated method stub
 		return null;
 	}
@@ -919,18 +906,17 @@ public class MockSBuildType implements SBuildType {
 	@Override
 	public void setEnabled(String arg0, boolean arg1) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
-	public boolean updateBuildTrigger(String arg0, String arg1,
-			Map<String, String> arg2) {
+	public boolean updateBuildTrigger(String arg0, String arg1, Map<String, String> arg2) {
 		// TODO Auto-generated method stub
 		return false;
 	}
-	
+
 	// From 8.0
-	
+
 	@Override
 	public File getConfigurationFile() {
 		// TODO Auto-generated method stub
@@ -950,14 +936,13 @@ public class MockSBuildType implements SBuildType {
 	@Override
 	public void remove() {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
-	public void setExternalId(String arg0) throws InvalidIdentifierException,
-			DuplicateExternalIdException {
+	public void setExternalId(String arg0) throws InvalidIdentifierException, DuplicateExternalIdException {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
@@ -996,10 +981,9 @@ public class MockSBuildType implements SBuildType {
 	}
 
 	@Override
-	public void attachToTemplate(BuildTypeTemplate arg0)
-			throws CannotAttachToTemplateException {
+	public void attachToTemplate(BuildTypeTemplate arg0) throws CannotAttachToTemplateException {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
@@ -1021,10 +1005,210 @@ public class MockSBuildType implements SBuildType {
 	}
 
 	@Override
-	public void moveToProject(SProject arg0)
-			throws InvalidVcsRootScopeException {
+	public void moveToProject(SProject arg0) throws InvalidVcsRootScopeException {
 		// TODO Auto-generated method stub
-		
+
+	}
+
+	@Override
+	public void setExternalId(ConfigAction arg0, String arg1)
+			throws InvalidIdentifierException, DuplicateExternalIdException, ObsoleteEntityException {
+
+	}
+
+	@Override
+	public String getConfigId() {
+		return null;
+	}
+
+	@Override
+	public File getConfigurationFile(File arg0) {
+		return null;
+	}
+
+	@Override
+	public PersistentEntityVersion getVersion() {
+		return null;
+	}
+
+	@Override
+	public void markPersisted(long arg0) {
+
+	}
+
+	@Override
+	public void persist(ConfigAction arg0) throws PersistFailedException {
+
+	}
+
+	@Override
+	public void addArtifactDependency(SArtifactDependency arg0) {
+
+	}
+
+	@Override
+	public SBuildFeatureDescriptor findBuildFeatureById(String arg0) {
+		return null;
+	}
+
+	@Override
+	public List<Requirement> getBuildFeatureRequirements() {
+		return null;
+	}
+
+	@Override
+	public Collection<SBuildFeatureDescriptor> getBuildFeaturesOfType(String arg0) {
+		return null;
+	}
+
+	@Override
+	public String[] getRunnersOrder() {
+		return null;
+	}
+
+	@Override
+	public List<String> getTemplateIds() {
+		return null;
+	}
+
+	@Override
+	public List<? extends BuildTypeTemplate> getTemplates() {
+		return null;
+	}
+
+	@Override
+	public <T> TypedValue<T> getTypedOption(Option<T> arg0) {
+		return null;
+	}
+
+	@Override
+	public boolean isCompositeBuildType() {
+		return false;
+	}
+
+	@Override
+	public boolean isTemplateAccessible() {
+		return false;
+	}
+
+	@Override
+	public void removeArtifactDependency(SArtifactDependency arg0) {
+
+	}
+
+	@Override
+	public void removeRequirement(Requirement arg0) {
+
+	}
+
+	@Override
+	public boolean replaceInValues(Pattern arg0, String arg1) {
+		return false;
+	}
+
+	@Override
+	public void resetRunnersOrder() {
+
+	}
+
+	@Override
+	public boolean textValueMatches(Pattern arg0) {
+		return false;
+	}
+
+	@Override
+	public <T> T getDeclaredOption(Option<T> arg0) {
+		return null;
+	}
+
+	@Override
+	public <T> T getOptionDefaultValue(Option<T> arg0) {
+		return null;
+	}
+
+	@Override
+	public Collection<Option> getOptions() {
+		return null;
+	}
+
+	@Override
+	public Collection<Option> getOwnOptions() {
+		return null;
+	}
+
+	@Override
+	public Parameter getOwnParameter(String arg0) {
+		return null;
+	}
+
+	@Override
+	public Parameter getParameter(String arg0) {
+		return null;
+	}
+
+	@Override
+	public String getParameterValue(String arg0) {
+		return null;
+	}
+
+	@Override
+	public void addTemplate(BuildTypeTemplate arg0, boolean arg1) {
+
+	}
+
+	@Override
+	public void forceCheckingForChanges(OperationRequestor arg0) {
+
+	}
+
+	@Override
+	public BranchFilter getBuildTypeBranchFilter() {
+		return null;
+	}
+
+	@Override
+	public List<? extends BuildTypeTemplate> getOwnTemplates() {
+		return null;
+	}
+
+	@Override
+	public String getReadOnlyReason() {
+		return null;
+	}
+
+	@Override
+	public VcsRootInstanceEntry getVcsRootInstanceEntryForParent(SVcsRoot arg0) {
+		return null;
+	}
+
+	@Override
+	public String getVcsRootsHash() {
+		return null;
+	}
+
+	@Override
+	public boolean isReadOnly() {
+		return false;
+	}
+
+	@Override
+	public void moveToProject(ConfigAction arg0, SProject arg1) throws InvalidVcsRootScopeException {
+
+	}
+
+	@Override
+	public void removeTemplates(Collection<? extends BuildTypeTemplate> arg0, boolean arg1) {
+
+	}
+
+	@Override
+	public void setTemplates(List<? extends BuildTypeTemplate> arg0, boolean arg1) {
+
+	}
+
+	@Override
+	public void setTemplatesOrder(List<String> arg0) {
+
 	}
 
 

--- a/tcmsteamsbuildnotifier-core/src/test/java/msteamsnotifications/teamcity/MockSProject.java
+++ b/tcmsteamsbuildnotifier-core/src/test/java/msteamsnotifications/teamcity/MockSProject.java
@@ -554,6 +554,158 @@ public class MockSProject implements SProject {
 		this.childProjects.add(sProject);
 	}
 
+	@Override
+	public String getConfigId() {
+		return null;
+	}
+
+	@Override
+	public File getConfigurationFile(File arg0) {
+		return null;
+	}
+
+	@Override
+	public PersistentEntityVersion getVersion() {
+		return null;
+	}
+
+	@Override
+	public void markPersisted(long arg0) {
+
+	}
+
+	@Override
+	public void persist(ConfigAction arg0) throws PersistFailedException {
+
+	}
+
+	@Override
+	public Parameter getOwnParameter(String arg0) {
+		return null;
+	}
+
+	@Override
+	public Parameter getParameter(String arg0) {
+		return null;
+	}
+
+	@Override
+	public String getParameterValue(String arg0) {
+		return null;
+	}
+
+	@Override
+	public void addFeature(SProjectFeatureDescriptor arg0) {
+
+	}
+
+	@Override
+	public SProjectFeatureDescriptor addFeature(String arg0, Map<String, String> arg1) {
+		return null;
+	}
+
+	@Override
+	public SVcsRoot createDummyVcsRoot(String arg0, Map<String, String> arg1) {
+		return null;
+	}
+
+	@Override
+	public SBuildType findBuildTypeByExternalId(String arg0) {
+		return null;
+	}
+
+	@Override
+	public SProjectFeatureDescriptor findFeatureById(String arg0) {
+		return null;
+	}
+
+	@Override
+	public Collection<SProjectFeatureDescriptor> getAvailableFeatures() {
+		return null;
+	}
+
+	@Override
+	public Collection<SProjectFeatureDescriptor> getAvailableFeaturesOfType(String arg0) {
+		return null;
+	}
+
+	@Override
+	public List<SVcsRoot> getAvailableVcsRoots() {
+		return null;
+	}
+
+	@Override
+	public CustomDataStorage getCustomDataStorage(String arg0) {
+		return null;
+	}
+
+	@Override
+	public BuildTypeTemplate getDefaultTemplate() {
+		return null;
+	}
+
+	@Override
+	public String getDefaultTemplateId() {
+		return null;
+	}
+
+	@Override
+	public BuildTypeTemplate getOwnDefaultTemplate() {
+		return null;
+	}
+
+	@Override
+	public String getOwnDefaultTemplateId() {
+		return null;
+	}
+
+	@Override
+	public Collection<SProjectFeatureDescriptor> getOwnFeatures() {
+		return null;
+	}
+
+	@Override
+	public Collection<SProjectFeatureDescriptor> getOwnFeaturesOfType(String arg0) {
+		return null;
+	}
+
+	@Override
+	public String getReadOnlyReason() {
+		return null;
+	}
+
+	@Override
+	public Status getStatus(String arg0) {
+		return null;
+	}
+
+	@Override
+	public boolean isReadOnly() {
+		return false;
+	}
+
+	@Override
+	public void moveToProject(ConfigAction arg0, SProject arg1)
+			throws CyclicDependencyException, InvalidVcsRootScopeException {
+
+	}
+
+	@Override
+	public SProjectFeatureDescriptor removeFeature(String arg0) {
+		return null;
+	}
+
+	@Override
+	public void setExternalId(ConfigAction arg0, String arg1)
+			throws InvalidIdentifierException, DuplicateExternalIdException, ObsoleteEntityException {
+
+	}
+
+	@Override
+	public boolean updateFeature(String arg0, String arg1, Map<String, String> arg2) {
+		return false;
+	}
+
 	
 	
 	

--- a/tcmsteamsbuildnotifier-core/src/test/java/msteamsnotifications/teamcity/MockSRunningBuild.java
+++ b/tcmsteamsbuildnotifier-core/src/test/java/msteamsnotifications/teamcity/MockSRunningBuild.java
@@ -576,4 +576,34 @@ public class MockSRunningBuild implements SRunningBuild {
 		return null;
 	}
 
+	@Override
+	public BuildProblemData addUserBuildProblem(SUser arg0, String arg1) {
+		return null;
+	}
+
+	@Override
+	public Collection<SBuildFeatureDescriptor> getBuildFeaturesOfType(String arg0) {
+		return null;
+	}
+
+	@Override
+	public SFinishedBuild getRecentlyFinishedBuild() {
+		return null;
+	}
+
+	@Override
+	public boolean isAgentLessBuild() {
+		return false;
+	}
+
+	@Override
+	public void muteBuildProblems(SUser arg0, boolean arg1, String arg2) {
+
+	}
+
+	@Override
+	public int getAgentId() {
+		return 0;
+	}
+
 }

--- a/tcmsteamsbuildnotifier-core/src/test/java/msteamsnotifications/teamcity/MockSRunningBuild.java
+++ b/tcmsteamsbuildnotifier-core/src/test/java/msteamsnotifications/teamcity/MockSRunningBuild.java
@@ -515,7 +515,7 @@ public class MockSRunningBuild implements SRunningBuild {
 	}
 
 	@Override
-	public BuildProblemData addUserBuildProblem(User arg0, String arg1) {
+	public BuildProblemData addUserBuildProblem(SUser arg0, String arg1) {
 		// TODO Auto-generated method stub
 		return null;
 	}
@@ -545,7 +545,7 @@ public class MockSRunningBuild implements SRunningBuild {
 	}
 
 	@Override
-	public void muteBuildProblems(User arg0, boolean arg1, String arg2) {
+	public void muteBuildProblems(SUser arg0, boolean arg1, String arg2) {
 		// TODO Auto-generated method stub
 		
 	}
@@ -577,11 +577,6 @@ public class MockSRunningBuild implements SRunningBuild {
 	}
 
 	@Override
-	public BuildProblemData addUserBuildProblem(SUser arg0, String arg1) {
-		return null;
-	}
-
-	@Override
 	public Collection<SBuildFeatureDescriptor> getBuildFeaturesOfType(String arg0) {
 		return null;
 	}
@@ -594,11 +589,6 @@ public class MockSRunningBuild implements SRunningBuild {
 	@Override
 	public boolean isAgentLessBuild() {
 		return false;
-	}
-
-	@Override
-	public void muteBuildProblems(SUser arg0, boolean arg1, String arg2) {
-
 	}
 
 	@Override

--- a/tcmsteamsbuildnotifier-web-ui/pom.xml
+++ b/tcmsteamsbuildnotifier-web-ui/pom.xml
@@ -175,21 +175,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- TeamCity/webapps/WEB-INF/lib/runtime-util.jar -->
-        <!--<dependency>
-            <groupId>com.jetbrains.teamcity</groupId>
-            <artifactId>runtime-util</artifactId>
-            <version>7.1.0</version>
-            <scope>provided</scope>
-        </dependency>-->
-
-        <!-- TeamCity/webapps/WEB-INF/lib/server-model.jar -->
-        <!--
-            <dependency> <groupId>com.jetbrains.teamcity</groupId>
-            <artifactId>model</artifactId> <version>4.0.2</version>
-            <scope>provided</scope> </dependency>
-        -->
-
         <!-- TeamCity/webapps/WEB-INF/lib/common-api.jar -->
         <dependency>
             <groupId>org.jetbrains.teamcity</groupId>
@@ -204,13 +189,6 @@
             <version>7.0.3</version>
             <scope>provided</scope>
         </dependency>
-
-        <!--<dependency>
-            <groupId>com.jetbrains.teamcity</groupId>
-            <artifactId>annotations</artifactId>
-            <version>7.1.0</version>
-            <scope>provided</scope>
-        </dependency>-->
 
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/tcmsteamsbuildnotifier-web-ui/pom.xml
+++ b/tcmsteamsbuildnotifier-web-ui/pom.xml
@@ -169,19 +169,19 @@
 
         <!-- TeamCity/webapps/WEB-INF/lib/server-api.jar -->
         <dependency>
-            <groupId>com.jetbrains.teamcity</groupId>
+            <groupId>org.jetbrains.teamcity</groupId>
             <artifactId>server-api</artifactId>
-            <version>8.0.0</version>
+            <version>2019.1</version>
             <scope>provided</scope>
         </dependency>
 
         <!-- TeamCity/webapps/WEB-INF/lib/runtime-util.jar -->
-        <dependency>
+        <!--<dependency>
             <groupId>com.jetbrains.teamcity</groupId>
             <artifactId>runtime-util</artifactId>
             <version>7.1.0</version>
             <scope>provided</scope>
-        </dependency>
+        </dependency>-->
 
         <!-- TeamCity/webapps/WEB-INF/lib/server-model.jar -->
         <!--
@@ -192,9 +192,9 @@
 
         <!-- TeamCity/webapps/WEB-INF/lib/common-api.jar -->
         <dependency>
-            <groupId>com.jetbrains.teamcity</groupId>
+            <groupId>org.jetbrains.teamcity</groupId>
             <artifactId>common-api</artifactId>
-            <version>8.0.0</version>
+            <version>2019.1</version>
             <scope>provided</scope>
         </dependency>
 
@@ -205,12 +205,12 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
+        <!--<dependency>
             <groupId>com.jetbrains.teamcity</groupId>
             <artifactId>annotations</artifactId>
             <version>7.1.0</version>
             <scope>provided</scope>
-        </dependency>
+        </dependency>-->
 
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
- Updated Teamcity LIbraries to 2019.1
- Updated Google GSON Library to 2.8.5
- Removed unused components from the pom.xml files

This brings the plugin support to Teamcity 2019.1.  Please use version 1.0.x for previous versions of TeamCity.