### PR TITLE
Feature/log4j security update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- oraclejdk15
 deploy:
   provider: releases
   skip_cleanup: true

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/tcmsteamsbuildnotifier-core/module_tcmsteamsbuildnotifier-core.xml
+++ b/tcmsteamsbuildnotifier-core/module_tcmsteamsbuildnotifier-core.xml
@@ -70,7 +70,7 @@
     <path refid="library.maven:_org.mortbay.jetty:jetty-client:6.1.16.classpath"/>
     <path refid="library.maven:_org.mortbay.jetty:jetty-sslengine:6.1.16.classpath"/>
     <path refid="library.maven:_org.mortbay.jetty:jetty-util5:6.1.16.classpath"/>
-    <path refid="library.maven:_log4j:log4j:1.2.12.classpath"/>
+    <path refid="library.maven:_log4j:log4j:2.13.0.classpath"/>
     <path refid="library.maven:_org.mockito:mockito-all:1.8.0.classpath"/>
     <path refid="library.maven:_commons-beanutils:commons-beanutils:1.8.3.classpath"/>
   </path>
@@ -103,7 +103,7 @@
     <path refid="library.maven:_org.mortbay.jetty:jetty-client:6.1.16.classpath"/>
     <path refid="library.maven:_org.mortbay.jetty:jetty-sslengine:6.1.16.classpath"/>
     <path refid="library.maven:_org.mortbay.jetty:jetty-util5:6.1.16.classpath"/>
-    <path refid="library.maven:_log4j:log4j:1.2.12.classpath"/>
+    <path refid="library.maven:_log4j:log4j:2.13.0.classpath"/>
     <path refid="library.maven:_org.mockito:mockito-all:1.8.0.classpath"/>
     <path refid="library.maven:_commons-beanutils:commons-beanutils:1.8.3.classpath"/>
   </path>

--- a/tcmsteamsbuildnotifier-core/pom.xml
+++ b/tcmsteamsbuildnotifier-core/pom.xml
@@ -17,8 +17,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/tcmsteamsbuildnotifier-core/pom.xml
+++ b/tcmsteamsbuildnotifier-core/pom.xml
@@ -217,12 +217,7 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>2.13.0</version>
-			<scope>test</scope>
-		</dependency>
+
 
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/tcmsteamsbuildnotifier-core/pom.xml
+++ b/tcmsteamsbuildnotifier-core/pom.xml
@@ -218,8 +218,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>log4j-core</groupId>
-			<artifactId>log4j-core</artifactId>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j</artifactId>
 			<version>2.13.0</version>
 			<scope>test</scope>
 		</dependency>

--- a/tcmsteamsbuildnotifier-core/pom.xml
+++ b/tcmsteamsbuildnotifier-core/pom.xml
@@ -218,9 +218,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.12</version>
+			<groupId>log4j-core</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.13.0</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/tcmsteamsbuildnotifier-web-ui/module_tcmsteamsbuildnotifier-web-ui.xml
+++ b/tcmsteamsbuildnotifier-web-ui/module_tcmsteamsbuildnotifier-web-ui.xml
@@ -28,7 +28,7 @@
     <path refid="library.maven:_javax.servlet:servlet-api:2.5.classpath"/>
     <path refid="library.maven:_org.springframework:spring:2.0.1.classpath"/>
     <path refid="library.maven:_commons-logging:commons-logging:1.1.classpath"/>
-    <path refid="library.maven:_log4j:log4j:1.2.12.classpath"/>
+    <path refid="library.maven:_log4j:log4j:2.13.0.classpath"/>
     <path refid="library.maven:_logkit:logkit:1.0.1.classpath"/>
     <path refid="library.maven:_avalon-framework:avalon-framework:4.1.3.classpath"/>
     <path refid="library.maven:_com.thoughtworks.xstream:xstream:1.3.1.classpath"/>
@@ -57,7 +57,7 @@
     <path refid="library.maven:_javax.servlet:servlet-api:2.5.classpath"/>
     <path refid="library.maven:_org.springframework:spring:2.0.1.classpath"/>
     <path refid="library.maven:_commons-logging:commons-logging:1.1.classpath"/>
-    <path refid="library.maven:_log4j:log4j:1.2.12.classpath"/>
+    <path refid="library.maven:_log4j:log4j:2.13.0.classpath"/>
     <path refid="library.maven:_logkit:logkit:1.0.1.classpath"/>
     <path refid="library.maven:_avalon-framework:avalon-framework:4.1.3.classpath"/>
     <path refid="library.maven:_com.thoughtworks.xstream:xstream:1.3.1.classpath"/>
@@ -84,7 +84,7 @@
     <path refid="library.maven:_javax.servlet:servlet-api:2.5.classpath"/>
     <path refid="library.maven:_org.springframework:spring:2.0.1.classpath"/>
     <path refid="library.maven:_commons-logging:commons-logging:1.1.classpath"/>
-    <path refid="library.maven:_log4j:log4j:1.2.12.classpath"/>
+    <path refid="library.maven:_log4j:log4j:2.13.0.classpath"/>
     <path refid="library.maven:_logkit:logkit:1.0.1.classpath"/>
     <path refid="library.maven:_avalon-framework:avalon-framework:4.1.3.classpath"/>
     <path refid="library.maven:_com.thoughtworks.xstream:xstream:1.3.1.classpath"/>

--- a/tcmsteamsbuildnotifier-web-ui/pom.xml
+++ b/tcmsteamsbuildnotifier-web-ui/pom.xml
@@ -80,8 +80,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Removed the log4j component because of the security risk, and the fact that it's only used in the tests.